### PR TITLE
Claire/task update fix

### DIFF
--- a/app/assets/javascripts/components/Dashboard.jsx
+++ b/app/assets/javascripts/components/Dashboard.jsx
@@ -113,7 +113,11 @@ class Dashboard extends React.Component {
   }
 
   taskUpdated = (tasks) => {
-    this.setState({ activeTasks: tasks });
+    if (tasks[0].completed_status === "archived") {
+      this.setState({ completedTasks: tasks });
+    } else {
+      this.setState({ activeTasks: tasks });
+    }
   }
 
   render() {

--- a/app/assets/javascripts/components/Dashboard.jsx
+++ b/app/assets/javascripts/components/Dashboard.jsx
@@ -7,10 +7,10 @@ class Dashboard extends React.Component {
       completedTasks: [],
       selectedTask: null,
     }
+    this.taskUpdated = this.taskUpdated.bind(this);
   }
 
   componentDidMount() {
-
     Requester.get(`/api/users/${this.props.user.id}/activetasks`).then((tasks) => {
       this.setState({ activeTasks: tasks });
     });
@@ -18,7 +18,6 @@ class Dashboard extends React.Component {
     Requester.get(`/api/users/${this.props.user.id}/completedtasks`).then((tasks) => {
       this.setState({ completedTasks: tasks });
     });
-
   }
 
   selectTask = (task, event) => {
@@ -104,11 +103,17 @@ class Dashboard extends React.Component {
           <p>{task.due_date.substring(0, 10)}</p>
             <TaskEditForm
               id={task.id}
+              listener={this.taskUpdated}
+              currentUser={this.props.user.id}
             />
         </div>
       )
     }
     return
+  }
+
+  taskUpdated = (tasks) => {
+    this.setState({ activeTasks: tasks });
   }
 
   render() {
@@ -120,7 +125,10 @@ class Dashboard extends React.Component {
           <div className="container">
             <h2 className="page-bar-title">My Dashboard</h2>
             <div className="page-bar-right">
-              <TaskCreationForm />
+              <TaskCreationForm
+                listener={this.taskUpdated}
+                currentUser={this.props.user.id}
+              />
             </div>
           </div>
         </div>

--- a/app/assets/javascripts/components/Dashboard.jsx
+++ b/app/assets/javascripts/components/Dashboard.jsx
@@ -90,7 +90,6 @@ class Dashboard extends React.Component {
 
   renderSelectedTask = () => {
     const { selectedTask } = this.state;
-
     let task = this.findTaskInArray(selectedTask, this.state.activeTasks);
     if (task == null) {
       task = this.findTaskInArray(selectedTask, this.state.completedTasks);
@@ -112,11 +111,15 @@ class Dashboard extends React.Component {
     return
   }
 
-  taskUpdated = (tasks) => {
-    if (tasks[0].completed_status === "archived") {
-      this.setState({ completedTasks: tasks });
+  taskUpdated = (info) => {
+    if (info.completed && info.hide) {
+      this.setState({ completedTasks: info.tasks, selectedTask: null });
+    } else if (info.completed) {
+      this.setState({ completedTasks: info.tasks });
+    } else if (info.hide) {
+      this.setState({ activeTasks: info.tasks, selectedTask: null });
     } else {
-      this.setState({ activeTasks: tasks });
+      this.setState({ activeTasks: info.tasks });
     }
   }
 

--- a/app/assets/javascripts/components/MentionInput.jsx
+++ b/app/assets/javascripts/components/MentionInput.jsx
@@ -9,7 +9,7 @@ class MentionInput extends React.Component {
         idToUsers: {},
         showUsers: false,
         mentionedUsers: [],
-        value: ''
+        value: ""
       }
     }
 
@@ -22,7 +22,7 @@ class MentionInput extends React.Component {
             userIdToName[user.id] = user.first_name + " " + user.last_name;
         });
         this.setState({ idToUsers: userIdToName });
-        if (!this.props.mention) {
+        if (!this.props.mention && this.props.searchProps != undefined) {
           this.setState({mentionedUsers: [this.props.searchProps], value: userIdToName[this.props.searchProps]});
         }
       });

--- a/app/assets/javascripts/components/dashboard/create_task.jsx
+++ b/app/assets/javascripts/components/dashboard/create_task.jsx
@@ -28,9 +28,11 @@ class TaskCreationForm extends DefaultModal {
       description: this.state.description,
       due_date: this.state.dueDate,
       title: this.state.name,
-      user_id: userInput
+      user_id: userInput,
+      current_user: this.props.currentUser,
     }
     Requester.post('/api/tasks', payload).then((data) => {
+      this.props.listener(data);
       this.closeModal();
     }).catch((data) => {
       console.error(data);

--- a/app/assets/javascripts/components/dashboard/create_task.jsx
+++ b/app/assets/javascripts/components/dashboard/create_task.jsx
@@ -29,7 +29,7 @@ class TaskCreationForm extends DefaultModal {
       due_date: this.state.dueDate,
       title: this.state.name,
       user_id: userInput,
-      current_user: this.props.currentUser,
+      current_user_id: this.props.currentUser,
     }
     Requester.post('/api/tasks', payload).then((data) => {
       this.props.listener(data);

--- a/app/assets/javascripts/components/dashboard/edit_task.jsx
+++ b/app/assets/javascripts/components/dashboard/edit_task.jsx
@@ -27,6 +27,20 @@ class TaskEditForm extends DefaultModal {
     });
   }
 
+  componentWillReceiveProps(nextProps) {
+    console.log(nextProps);
+    // Check if props are equivalent???
+    Requester.get(`/api/tasks/${nextProps.id}/get`).then((info) => {
+      this.setState({
+        description: info.task.description,
+        title: info.task.title,
+        dueDate: info.task.due_date.substring(0, 10),
+        initialClientID: info.task.client_id,
+        initialAttorneyID: info.user
+      });
+    });
+  }
+
   select = (event) => {
     this.setState({[event.target.name]: event.target.value});
   }
@@ -44,10 +58,12 @@ class TaskEditForm extends DefaultModal {
       due_date: this.state.dueDate,
       title: this.state.title,
       user_id: userInput,
-      task_id: this.props.id
+      task_id: this.props.id,
+      current_user: this.props.currentUser
     }
 
     Requester.update(`/api/tasks/`, payload).then((data) => {
+      this.props.listener(data);
       this.closeModal();
     }).catch((data) => {
       console.error(data);

--- a/app/assets/javascripts/components/dashboard/edit_task.jsx
+++ b/app/assets/javascripts/components/dashboard/edit_task.jsx
@@ -28,16 +28,17 @@ class TaskEditForm extends DefaultModal {
   }
 
   componentWillReceiveProps(nextProps) {
-    // Check if props are equivalent???
-    Requester.get(`/api/tasks/${nextProps.id}/get`).then((info) => {
-      this.setState({
-        description: info.task.description,
-        title: info.task.title,
-        dueDate: info.task.due_date.substring(0, 10),
-        initialClientID: info.task.client_id,
-        initialAttorneyID: info.user
+    if (this.props != nextProps) {
+      Requester.get(`/api/tasks/${nextProps.id}/get`).then((info) => {
+        this.setState({
+          description: info.task.description,
+          title: info.task.title,
+          dueDate: info.task.due_date.substring(0, 10),
+          initialClientID: info.task.client_id,
+          initialAttorneyID: info.user
+        });
       });
-    });
+    }
   }
 
   select = (event) => {
@@ -58,7 +59,7 @@ class TaskEditForm extends DefaultModal {
       title: this.state.title,
       user_id: userInput,
       task_id: this.props.id,
-      current_user: this.props.currentUser
+      current_user_id: this.props.currentUser
     }
 
     Requester.update(`/api/tasks/`, payload).then((data) => {

--- a/app/assets/javascripts/components/dashboard/edit_task.jsx
+++ b/app/assets/javascripts/components/dashboard/edit_task.jsx
@@ -28,7 +28,6 @@ class TaskEditForm extends DefaultModal {
   }
 
   componentWillReceiveProps(nextProps) {
-    console.log(nextProps);
     // Check if props are equivalent???
     Requester.get(`/api/tasks/${nextProps.id}/get`).then((info) => {
       this.setState({

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -3,9 +3,9 @@ class API::TasksController < ApplicationController
   respond_to :json
 
   def get_task
-    @task = Task.find(params[:task_id])
-    @user = @task.users.first.id
-    render json: {"task": @task, "user": @user}
+    task = Task.find(params[:task_id])
+    user = task.users.first.id
+    render json: {"task": task, "user": user}
   end
 
   def update
@@ -16,9 +16,10 @@ class API::TasksController < ApplicationController
     if @task.users.first.id != params[:user_id]
       self.unassign(@task.users.first.id, @task.id)
       self.assign(params[:user_id], @task.id)
-    else
-      render(:json => {:message => 'Task successfully updated!'}.to_json)
     end
+    user = User.find(params[:current_user])
+    tasks = user.tasks.where(:completed_status => 0).order(:due_date)
+    render json: tasks
   end
 
   def show
@@ -31,6 +32,10 @@ class API::TasksController < ApplicationController
     task = Task.new(:client_id => params['client_id'], :description => params['description'], :title => params['title'], :due_date => params['due_date'])
     saved = task.save!
     self.assign(params[:user_id], task.id)
+
+    user = User.find(params[:current_user])
+    tasks = user.tasks.where(:completed_status => 0).order(:due_date)
+    render json: tasks
   end
 
   def destroy
@@ -46,17 +51,12 @@ class API::TasksController < ApplicationController
     user = User.find(user_id)
     task = Task.find(task_id)
     a = user.tasks << task
-    if a
-      n = Notification.create(
-        notification_type: Notification.types[:task_assigned],
-        user: user,
-        notified_by: current_user,
-        notifiable: task,
-      )
-      render(:json => {:message => 'Task successfully updated!'}.to_json)
-    else
-      render(json: user.errors.full_messages, :status => 422)
-    end
+    n = Notification.create(
+      notification_type: Notification.types[:task_assigned],
+      user: user,
+      notified_by: current_user,
+      notifiable: task,
+    )
   end
 
   def unassign(user_id, task_id)
@@ -97,5 +97,6 @@ class API::TasksController < ApplicationController
     params.require(:due_date)
     params.require(:title)
     params.require(:user_id)
+    params.require(:current_user)
   end
 end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -18,7 +18,11 @@ class API::TasksController < ApplicationController
       self.assign(params[:user_id], @task.id)
     end
     user = User.find(params[:current_user])
-    tasks = user.tasks.where(:completed_status => 0).order(:due_date)
+    if @task.completed_status == 0
+      tasks = user.tasks.where(:completed_status => 0).order(:due_date)
+    else
+      tasks = user.tasks.where(:completed_status => 1).order(:updated_at).reverse_order
+    end
     render json: tasks
   end
 


### PR DESCRIPTION
### What does this PR do?
- Automatically renders task upon update/creation. 
- Adds listener to `TaskEditForm` and `TaskCreateForm` that updates `Dashboard` state upon form submission.
- Modifies `update` and `create` methods in `TaskController` to return the list of sorted tasks after inserting the updated task so that the list renders properly in `Dashboard`.

Possible bugs:
- Strange bug on ReactJS comes up whenever a task is edited and reassigned to a new user perhaps related to "Close Modal".
- Removed error messages in `TaskController`. I don't think that there should be problems associated with this, but it would be great if anybody could check over this.

### Status
READY

### Migrations
NO

### Related PRs
List related PRs against other branches:
None
### Description of Testing Done

### Todos
- [ ] Testing
- [ ] Documentation/`annotate`

### Screenshots