### PR TITLE
Claire/Toggle Un/Read Notifications

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -52,15 +52,20 @@ class API::UsersController < ApplicationController
     params.require(:user).permit(:email, :first_name, :last_name, :password, :avatar)
   end
 
-  def user_notifications
+  def user_read_notifications
   	user = User.find(params[:id])
-  	notifications = user.notifications
+  	notifications = user.notifications.where(read: true).order(updated_at: :desc)
+  	render json: notifications
+  end
+
+  def user_unread_notifications
+  	user = User.find(params[:id])
+  	notifications = user.notifications.where(read: false).order(updated_at: :desc)
   	render json: notifications
   end
 
   def read_notification
     updated = Notification.find(params[:notif_id]).update({read: true})
-
     if updated
       render json: {message: 'success'}
     else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,8 @@ Rails.application.routes.draw do
     put 'tasks/complete', to: 'tasks#complete'
     put 'tasks/uncomplete', to: 'tasks#uncomplete'
 
-    get '/users/:id/notifications', to: 'users#user_notifications'
+    get '/users/:id/readnotifications', to: 'users#user_read_notifications'
+    get '/users/:id/unreadnotifications', to: 'users#user_unread_notifications'
     put '/users/:id/notifications/:notif_id/read', to: 'users#read_notification'
     put '/users/:id/notifications/read', to: 'users#read_all_notifications'
 


### PR DESCRIPTION
### What does this PR do?
This PR separates read/unread notification retrieval and display. I created different routes for retrieving read and unread notifications, and then refactored the `NotificationsList` component to display the two groups separately.

### Status
READY

### Migrations
NO

### Related PRs
List related PRs against other branches: None

### Description of Testing Done
Tested by creating tasks/comments and then marking them as un/read.

### Todos
- [ ] Testing
- [ ] Documentation/`annotate`

### Screenshots
![screen shot 2018-03-21 at 3 29 14 pm](https://user-images.githubusercontent.com/29110579/37741030-1e841316-2d1d-11e8-8a7f-fbabfe2ef056.png)
